### PR TITLE
Allows code to catch an IndexError if the composer tries to write to …

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.8.4
+current_version = 0.8.5
 commit = False
 tag = False
 allow_dirty = False

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,8 @@ jobs:
           root: .
           # Must be relative path from root
           paths:
-            - dist/htmxl-0.8.4.tar.gz
-            - dist/htmxl-0.8.4-py3-none-any.whl
+            - dist/htmxl-0.8.5.tar.gz
+            - dist/htmxl-0.8.5-py3-none-any.whl
 
   test:
     executor: main

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,8 +12,8 @@ import sys
 sys.path.insert(0, os.path.abspath(".."))
 
 project = "HTM(x)L"
-version = "0.8.4"
-release = "0.8.4"
+version = "0.8.5"
+release = "0.8.5"
 
 extensions = [
     "m2r2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "htmxl"
-version = "0.8.4"
+version = "0.8.5"
 description = "Produce Excel files from HTML templates."
 authors = [
     "Hunter Senft-Grupp <hunter@janux.io>",

--- a/src/htmxl/alphabet.py
+++ b/src/htmxl/alphabet.py
@@ -37,7 +37,7 @@ class _Alphabet:
     def __getitem__(self, item):
         try:
             return self.letters[item]
-        except KeyError:
+        except (IndexError, KeyError):
             self._generate_more_letters(item)
             return self.letters[item]
 

--- a/tests/test_compose/test_write/test_alphabet.py
+++ b/tests/test_compose/test_write/test_alphabet.py
@@ -1,6 +1,6 @@
 import pytest
 
-from htmxl.alphabet import _column_letters
+from htmxl.alphabet import _Alphabet, _column_letters
 
 
 @pytest.mark.this
@@ -41,3 +41,9 @@ def test_column_letter_factory():
         "AC",
         "AD",
     ]
+
+
+@pytest.mark.this
+def test_letters_generated_on_overflow():
+    alphabet = _Alphabet()
+    assert alphabet[26] == "AA"


### PR DESCRIPTION
…a column that is greater than the index corresponding to Z.

The implementation currently assumes columns are accessed by key (and adds more letters if a `KeyError` is encountered at runtime):

```
     37 def __getitem__(self, item):
     38     try:
---> 39         return self.letters[item]
     40     except KeyError:
     41         self._generate_more_letters(item)
```

However, `self.letters` is actually accessed by `index`, per:
```
     33 @classmethod
     34 def from_location(cls, col, row):
---> 35     col = alphabet[col - 1]
     36     ref = f"{col}{row}"
     37     return cls(ref)
```
