### PR TITLE
feat: Add recover argument to lxml parser.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "htmxl"
-version = "0.8.5"
+version = "0.8.6"
 description = "Produce Excel files from HTML templates."
 authors = [
     "Hunter Senft-Grupp <hunter@janux.io>",

--- a/src/htmxl/token.py
+++ b/src/htmxl/token.py
@@ -70,7 +70,7 @@ class LxmlStream(TokenStream):
     def parse_str(cls, data: str):
         from lxml import etree
 
-        parser = etree.XMLParser(remove_blank_text=True)
+        parser = etree.XMLParser(remove_blank_text=True, recover=True)
 
         # Lxml requires a single top-level node.
         data = f"<root>{data}</root>"


### PR DESCRIPTION
recover: "try hard to parse through broken XML"

This is to address the error lxml.etree.XMLSyntaxError: EntityRef: expecting ';', line 1065, column 110

