### PR TITLE
feat: Allow renaming sheets, empty elements

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,8 @@ jobs:
           root: .
           # Must be relative path from root
           paths:
-            - dist/htmxl-0.8.5.tar.gz
-            - dist/htmxl-0.8.5-py3-none-any.whl
+            - dist/htmxl-*.tar.gz
+            - dist/htmxl-*-py3-none-any.whl
 
   test:
     executor: main

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "htmxl"
-version = "0.8.6"
+version = "0.8.7"
 description = "Produce Excel files from HTML templates."
 authors = [
     "Hunter Senft-Grupp <hunter@janux.io>",

--- a/src/htmxl/compose/workbook.py
+++ b/src/htmxl/compose/workbook.py
@@ -26,24 +26,29 @@ class Workbook:
         self.styler = Styler(self.wb, styles)
         self.parser = parser
 
-    def new_worksheet(self, parser=None):
-        worksheet = Worksheet(styler=self.styler, wb=self.wb, parser=parser or self.parser)
+    def new_worksheet(self, parser=None, sheet_name=None):
+        worksheet = Worksheet(
+            styler=self.styler,
+            wb=self.wb,
+            parser=parser or self.parser,
+            sheet_name=sheet_name,
+        )
         self.worksheets.append(worksheet)
 
         return worksheet
 
-    def add_sheet_from_template_file(self, template_file, data=None):
+    def add_sheet_from_template_file(self, template_file, data=None, sheet_name=None):
         if data is None:
             data = {}
 
         with open(template_file, "r") as f:
-            return self.add_sheet_from_template(template=f.read(), data=data)
+            return self.add_sheet_from_template(template=f.read(), data=data, sheet_name=sheet_name)
 
-    def add_sheet_from_template(self, template, data=None, parser=None):
+    def add_sheet_from_template(self, template, data=None, parser=None, sheet_name=None):
         if data is None:
             data = {}
 
-        worksheet = self.new_worksheet(parser=parser or self.parser)
+        worksheet = self.new_worksheet(parser=parser or self.parser, sheet_name=sheet_name)
         worksheet.template = jinja_env.from_string(template)
         worksheet.data = data
         return worksheet
@@ -64,8 +69,8 @@ class Workbook:
 
 
 class Worksheet:
-    def __init__(self, wb, styler, parser=None):
-        self.sheet_name = str(uuid.uuid4())[0:8]
+    def __init__(self, wb, styler, parser=None, sheet_name=None):
+        self.sheet_name = sheet_name or str(uuid.uuid4())[0:8]
         self.writer = Writer(wb.create_sheet(self.sheet_name))
         self.styler = styler
         self.data = {}

--- a/src/htmxl/compose/write/elements.py
+++ b/src/htmxl/compose/write/elements.py
@@ -103,7 +103,9 @@ def write_th(element, writer, styler, style):
     with writer.record() as recording:
         data_type = _type_map[element.attrs.get("data-type")]
         logger.debug("Setting cell {} to {}".format(writer.ref, data_type))
-        write_value(data_type(element.text.strip()), writer, styler, style)
+        write_value(
+            data_type(element.text.strip() if element.text else None), writer, styler, style
+        )
 
         colspan = int(element.attrs.get("colspan", 1))
         rowspan = int(element.attrs.get("rowspan", 1))

--- a/tests/test_compose/test_empty_elements.py
+++ b/tests/test_compose/test_empty_elements.py
@@ -1,0 +1,21 @@
+import io
+
+from htmxl.compose import Workbook
+
+data = dict(
+    title="Hello World",
+    name="Bob",
+    column_names=["A", "B"],
+    rows=[{"a": str(i), "b": int(i)} for i in range(10000)],
+)
+
+
+def test_sheet_with_empty_elements():
+    with open("tests/test_empty_elements.jinja2") as f:
+        template = f.read()
+
+    workbook = Workbook(parser="lxml")
+    workbook.add_sheet_from_template(template=template, data=data)
+
+    buffer = io.BytesIO()
+    workbook.compose(buffer)

--- a/tests/test_compose/test_name_sheet.py
+++ b/tests/test_compose/test_name_sheet.py
@@ -1,0 +1,27 @@
+import io
+
+import openpyxl
+
+from htmxl.compose import Workbook
+
+data = dict(
+    title="Hello World",
+    name="Bob",
+    column_names=["A", "B"],
+    rows=[{"a": str(i), "b": int(i)} for i in range(10000)],
+)
+
+
+def test_name_sheet():
+    with open("tests/test_performance.jinja2") as f:
+        template = f.read()
+
+    SHEET_NAME = "Test Foo 123"
+    workbook = Workbook(parser="lxml")
+    workbook.add_sheet_from_template(template=template, data=data, sheet_name=SHEET_NAME)
+
+    buffer = io.BytesIO()
+    workbook.compose(buffer)
+
+    wb = openpyxl.load_workbook(buffer)
+    assert wb.sheetnames == [SHEET_NAME]

--- a/tests/test_empty_elements.jinja2
+++ b/tests/test_empty_elements.jinja2
@@ -1,0 +1,25 @@
+<head>{{ title }}</head>
+<body>
+  <div>
+    Hello down there, {{ name }}!
+  </div>
+  <table>
+    <thead>
+      <tr>
+        <th/>
+        {% for column_name in column_names %}
+          <th>{{ column_name }}</th>
+        {% endfor %}
+      </tr>
+    </thead>
+    <tbody>
+      {% for row in rows %}
+        <tr>
+          <td></td>
+          <td>{{ row.a }}</td>
+          <td>{{ row.b }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</body>


### PR DESCRIPTION
While using HTMXL for some ASO work, I noticed the following limitations:

* Inability to rename sheets -- HTMXL just always applies a random UUID string sheet name
* Cannot have totally empty elements, e.g. `<td />` if I just wanted a spacer column

While I could just open the generated workbook with openpyxl and make these changes after generating the excel file, I figured these seem like things other people may want to use in HTMXL, and am thus making this PR.